### PR TITLE
GREEN-475-fix-env

### DIFF
--- a/green-ev/lib/api.ts
+++ b/green-ev/lib/api.ts
@@ -9,7 +9,7 @@ import {
   StationsSpots,
 } from './types'
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001'
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost'
 
 async function handleResponse<T>(response: Response): Promise<T> {
   if (!response.ok) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the default API base URL to use 'http://localhost' instead of 'http://localhost:8001' when no environment variable is set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->